### PR TITLE
[DO NOT MERGE] WIP: Make clone operations simplier

### DIFF
--- a/gitarro.rb
+++ b/gitarro.rb
@@ -12,6 +12,11 @@ prs = b.open_prs
 
 prs.each do |pr|
   puts '=' * 30 + "\n" + "TITLE_PR: #{pr.title}, NR: #{pr.number}\n" + '=' * 30
+  # Mark test as failed and skip thest if the PR mergeable_state is not clean
+  unless b.in_mergeable_state(pr)
+    puts 'PR mergeable state is not clean! Please fix conflicts before testing!'
+    next
+  end
   # this check the last commit state, catch for review or not reviewd status.
   comm_st = b.client.status(b.repo, pr.head.sha)
   # pr number trigger.

--- a/lib/gitarro/backend.rb
+++ b/lib/gitarro/backend.rb
@@ -19,13 +19,11 @@ class TestExecutor
 
   # this will clone the repo and execute the tests
   def pr_test(pr)
-    git = GitOp.new(@git_dir, pr, @options)
-    # merge PR-branch to upstream branch
-    git.merge_pr_totarget(pr.base.ref, pr.head.ref)
+    git = GitOp.new(@git_dir, @options)
+    # Get the PR
+    git.get_pr(pr.number, pr.base.ref)
     # do valid tests and store the result
     test_status = run_script
-    # del branch
-    git.del_pr_branch(pr.base.ref, pr.head.ref)
     test_status
   end
 
@@ -63,6 +61,12 @@ class Backend
     @gbexec = TestExecutor.new(@options)
   end
 
+  def create_status(pr_head_sha, status)
+    client.create_status(@repo, pr_head_sha, status, context: @context,
+                                                     description: @description,
+                                                     target_url: @target_url)
+  end
+
   # public method for get prs opens
   # given a repo
   def open_prs
@@ -71,31 +75,35 @@ class Backend
     prs
   end
 
+  def in_mergeable_state(pr)
+    if pr.mergeable_state != 'clean'
+      create_status(pr.head.sha, 'failure')
+      magicword(@repo, pr.number, @context)
+      return false
+    end
+    true
+  end
+
   # public for etrigger the test
   def retrigger_check(pr)
     return unless retrigger_needed?(pr)
-    client.create_status(@repo, pr.head.sha, 'pending',
-                         context: @context, description: @description,
-                         target_url: @target_url)
+    create_status(pr.head.sha, 'pending')
     exit 1 if @check
-    launch_test_and_setup_status(@repo, pr)
+    launch_test_and_setup_status(pr)
     j_status == 'success' ? exit(0) : exit(1)
   end
 
   # public always rerun tests against the pr number if this exists
   def trigger_by_pr_number(pr)
-    return false if @pr_number.nil?
-    return false if @pr_number != pr.number
+    return false if @pr_number.nil? || @pr_number != pr.number
     puts "Got triggered by PR_NUMBER OPTION, rerunning on #{@pr_number}"
-    launch_test_and_setup_status(@repo, pr)
+    launch_test_and_setup_status(pr)
     true
   end
 
   # public method, trigger changelogtest if option active
   def changelog_active(pr, comm_st)
-    return false unless @changelog_test
-    return false unless changelog_changed(@repo, pr, comm_st)
-    true
+    @changelog_test || changelog_changed(pr, comm_st) ? true : false
   end
 
   def unreviewed_pr_test(pr, comm_st)
@@ -105,7 +113,7 @@ class Backend
     # gb.check is true when there is a job running as scheduler
     # which doesn't execute the test but trigger another job
     return false if @check
-    launch_test_and_setup_status(@repo, pr)
+    launch_test_and_setup_status(pr)
     true
   end
 
@@ -128,17 +136,13 @@ class Backend
   # then set the status according to the results of script executed.
   # pr_head = is the PR branch
   # base = is a the upstream branch, where the pr targets
-  def launch_test_and_setup_status(repo, pr)
+  def launch_test_and_setup_status(pr)
     # pending
-    @client.create_status(repo, pr.head.sha, 'pending',
-                          context: @context, description: @description,
-                          target_url: @target_url)
+    create_status(pr.head.sha, 'pending')
     # do tests
     @j_status = gbexec.pr_test(pr)
     # set status
-    @client.create_status(repo, pr.head.sha, @j_status,
-                          context: @context, description: @description,
-                          target_url: @target_url)
+    create_status(pr.head.sha, @j_status)
   end
 
   # this function will check if the PR contains in comment the magic word
@@ -243,25 +247,22 @@ class Backend
     true
   end
 
-  def do_changelog_test(repo, pr)
+  def do_changelog_test(pr)
     @j_status = 'failure'
     pr_all_files_type(repo, pr.number, @file_type)
     # if the pr contains changes on .changes file, test ok
     @j_status = 'success' if @pr_files.any?
     magic_comment(repo, pr.number)
-    @client.create_status(repo, pr.head.sha, @j_status,
-                          context: @context, description: @description,
-                          target_url: @target_url)
+    create_status(pr.head.sha, @j_status)
     true
   end
 
   # do the changelog test and set status
-  def changelog_changed(repo, pr, comm_st)
+  def changelog_changed(pr, comm_st)
     return false unless @changelog_test
     # only execute 1 time, don"t run if test is failed, or ok
-    return false if failed_status?(comm_st)
-    return false if success_status?(comm_st)
-    do_changelog_test(repo, pr)
+    return false if failed_status?(comm_st) || success_status?(comm_st)
+    do_changelog_test(pr)
   end
 
   def retrigger_needed?(pr)
@@ -269,13 +270,12 @@ class Backend
     return false unless magicword(@repo, pr.number, @context)
     # changelog trigger
     if @changelog_test
-      do_changelog_test(@repo, pr)
+      do_changelog_test(pr)
       return false
     end
     pr_all_files_type(@repo, pr.number, @file_type)
-    return false unless @pr_files.any?
     # if check is set, the comment in the trigger job will be del.
     # so setting it to pending, it will be remembered
-    true
+    @pr_files.any ? true : false
   end
 end

--- a/lib/gitarro/git_op.rb
+++ b/lib/gitarro/git_op.rb
@@ -1,131 +1,106 @@
 #! /usr/bin/ruby
 
-require 'English'
 require 'fileutils'
-require 'timeout'
+require 'English'
 
-# This class is used by lib/backend.rb
-# git operation for gitarro
+# Representation of a commit with its attributes
+class Commit
+  attr_accessor :hash, :author_name, :author_email, :date
+end
+
+# git operation for gitbot
 class GitOp
-  attr_reader :git_dir, :pr, :pr_fix, :repo_external, :repo_protocol
-  def initialize(git_dir, pr, options)
-    @git_dir = git_dir
-    # prefix for the test pr that gitarro tests.
-    @pr_fix = 'PR-'
-    # pr object for extract all relev. data.
-    @pr = pr
-    # All gitarro options
-    @options = options
-    # object to handle external repos
-    @repo_external = ExternalRepoGit.new(pr, options)
-    gh = 'https://github.com/'
-    gg = 'git@github.com:'
-    @repo_protocol = @options[:https] ? gh : gg
+  def initialize(git_dir, options)
+    # GitHub URL depending on protocol
+    @repo_url = options[:https] ? 'https://github.com/' : 'git@github.com:'
+    @repo_url = @repo_url + options[:repo] + '.git'
+    # Repository name (without project)
+    repo_name = options[:repo].split('/')[1]
+    # Directory where the repository with the code to test will live
+    # append repository name to be retrocompatible
+    # But if it exists, use /tmp/gitbot/<repo_name>
+    @git_dir = git_dir + '/' + repo_name
+    # Clone style
+    @no_merge_upstream = options[:no_merge_upstream]
   end
 
-  # merge pr_branch into upstream targeted branch
-  def merge_pr_totarget(upstream, pr_branch)
-    goto_prj_dir
-    check_git_dir
-    `git checkout #{upstream}`
-    check_duplicata_pr_branch("#{pr_fix}#{pr_branch}")
-    `git remote update`
-    `git fetch`
-    `git pull origin #{upstream}`
-    `git checkout -b #{pr_fix}#{pr_branch} origin/#{pr_branch}`
-    return if $CHILD_STATUS.exitstatus.zero?
-    # if it fails the PR contain a forked external repo
-    repo_external.checkout_into
-  end
-
-  # cleanup the pr_branch(delete it)
-  def del_pr_branch(upstream, pr)
-    `git checkout #{upstream}`
-    `git branch -D  #{pr_fix}#{pr}`
-  end
-
-  private
-
-  def ck_or_clone_git
-    return if File.directory?(git_dir)
-    FileUtils.mkdir_p(git_dir)
-    Dir.chdir git_dir
-    repo_url = "#{repo_protocol}#{@options[:repo]}.git"
-    puts `git clone #{repo_url}`
-  end
-
-  # this function merge the pr branch  into target branch,
-  # where the author of pr wanted to submit
-  def goto_prj_dir
-    git_repo_dir = git_dir + '/' + @options[:repo].split('/')[1]
-    # chech that dir exist, otherwise clone it
-    ck_or_clone_git
-    begin
-      # /tmp/gitarro, this is in case the dir already exists
-      Dir.chdir git_repo_dir
-    rescue Errno::ENOENT
-      # this is in case we clone the repo
-      Dir.chdir @options[:repo].split('/')[1]
+  def get_pr(pr_number, pr_base_ref)
+    git_init(@git_dir)
+    git_remote_add('origin', @repo_url)
+    # PR standalone, last commit
+    if @no_merge_upstream
+      git_pull('origin', "refs/pull/#{pr_number}/head")
+    # The PR plus all commits from base until the common ancestor
+    else
+      # Rewind until we can pull --rebase pr_base_ref
+      git_pull_rewind('origin', "refs/pull/#{pr_number}/head", pr_base_ref)
     end
   end
 
-  def check_git_dir
-    msg_err = 'gitarro is not working on a git directory'
-    raise msg_err if File.directory?('.git') == false
+  def can_pull_merge(origin, base_ref, depth)
+    puts `git pull --depth #{depth} --no-edit #{origin} #{base_ref}`
+    $CHILD_STATUS.exitstatus.zero?
   end
 
-  # this is for preventing that a test branch exists already
-  # and we have some internal error
-  def check_duplicata_pr_branch(pr)
-    puts `git branch --list #{pr}`
-    `git branch -D #{pr} 2>/dev/null` if $CHILD_STATUS.exitstatus.zero?
-  end
-end
-
-# This private class handle the case the repo from PR
-# comes from a user external repo
-# PR open against: openSUSE/gitarro
-# PR repo:  MyUSER/gitarro
-class ExternalRepoGit
-  attr_reader :pr, :rem_repo, :pr_fix
-  def initialize(pr, options)
-    # pr object for extract all relev. data.
-    @pr = pr
-    @pr_fix = 'PR-'
-    @options = options
+  def error_max_rewind(cur, max, ref)
+    return unless cur >= max
+    puts "\nERROR: Rewinded more than commits 100 without being able to merge!"
+    puts "And cound not find it!\n\n"
+    puts "Either PR lacks of a parent commit at #{ref} you just have too"
+    puts 'many commits and you need to squash your commits to make the PR '
+    puts "easier!\n"
+    exit 1
   end
 
-  def checkout_into
-    rem_repo = 'rem' + pr.head.ref
-    add_remote(rem_repo)
-    fetch_remote(rem_repo)
-    checkout_to_rem_branch(rem_repo)
-    remove_repo(rem_repo)
+  def git_init(dir)
+    # Remove the directory if it exists
+    FileUtils.remove_entry_secure(dir) if File.directory?(dir)
+    puts `git init #{dir}`
+    exit 1 if $CHILD_STATUS.exitstatus.nonzero?
+    Dir.chdir dir
   end
 
-  private
-
-  def checkout_to_rem_branch(rem_repo)
-    puts `git checkout -b #{pr_fix}#{branch_rem} #{rem_repo}/#{branch_rem}`
+  def git_remote_add(remote, url)
+    puts `git remote add #{remote} #{url}`
     exit 1 if $CHILD_STATUS.exitstatus.nonzero?
   end
 
-  def branch_rem
-    pr.head.ref
+  def git_pull_rewind(origin, ref, base_ref)
+    # Download commits backwards starting from PR head until we can rebase
+    # base_ref
+    i = 1
+    loop do
+      puts "\n*** Downloading from #{origin} #{ref}, depth #{i}\n\n"
+      git_pull(origin, ref, i)
+      puts "\n*** Downloading from #{origin} #{base_ref}, depth #{i}\n\n"
+      break if can_pull_merge(origin, base_ref, i)
+      i += 1
+      error_max_rewind(i, 101, base_ref)
+    end
   end
 
-  def add_remote(rem_repo)
-    repo_url = @options[:https] ? pr.head.repo.html_url : pr.head.repo.ssh_url
-    puts `git remote add #{rem_repo} #{repo_url}`
+  def git_pull(remote, ref, depth = 1)
+    # To support changing pulling depth in the future
+    depth_param = depth == -1 ? '' : "--depth #{depth}"
+    puts `git pull #{depth_param} #{remote} #{ref}`
+    exit 1 if $CHILD_STATUS.exitstatus.nonzero?
   end
 
-  def fetch_remote(rem_repo)
-    puts `git remote update`
-    puts `git fetch`
-    puts `git pull #{rem_repo} #{pr.head.ref}`
+  def current_commit
+    commit = Commit.new
+    commit.hash = `git log --pretty=format:'%H' -n 1`
+    commit.author_name = `git log --pretty=format:'%an' -n 1`
+    commit.author_email = `git log --pretty=format:'%ae' -n 1`
+    commit.date = `git log --pretty=format:'%ad' -n 1`
+    commit
   end
 
-  def remove_repo(rem_repo)
-    puts `git remote remove #{rem_repo}`
+  def print_commit_info(pr)
+    commit = current_commit
+    puts "\nThe following commit is to be tested:\n" \
+      "- LOCAL HASH:  #{commit.hash}\n" \
+      "- REPO ORIG:   #{pr.head.repo.full_name}\n" \
+      "- BRANCH_ORIG: #{pr.head.ref}\n" \
+      "- HASH_ORIG:   #{pr.head.sha}\n\n" \
   end
 end

--- a/lib/gitarro/opt_parser.rb
+++ b/lib/gitarro/opt_parser.rb
@@ -91,6 +91,13 @@ module OptionalOptions
     end
   end
 
+  def no_merge_upstream(opt)
+    desc = 'Test without merging changes from master into the PR code'
+    opt.on('--no_merge_upstream', desc) do |no_merge_upstream|
+      @options[:no_merge_upstream] = no_merge_upstream
+    end
+  end
+
   def optional_options(opt)
     opt.separator ''
     opt.separator 'Optional options:'
@@ -100,6 +107,7 @@ module OptionalOptions
     url_opt(opt)
     pr_number(opt)
     https_opt(opt)
+    no_merge_upstream(opt)
   end
 end
 
@@ -164,6 +172,7 @@ class OptParserInternal
     @options[:changelog_test] = false if @options[:changelog_test].nil?
     @options[:target_url] = '' if @options[:target_url].nil?
     @options[:https] = false if @options[:https].nil?
+    @options[:no_merge_upstream] = false if @options[:no_merge_upstream].nil?
   end
 
   def defaults_to_text

--- a/tests/unit_tests/t_backend.rb
+++ b/tests/unit_tests/t_backend.rb
@@ -8,7 +8,7 @@ class BackendTest2 < Minitest::Test
   def test_full_option_import2
     @full_hash = { repo: 'gino/gitarro', context: 'python-t', description:
                    'functional', test_file: 'gino.sh', file_type: '.sh',
-                   git_dir: 'gitty' }
+                   git_dir: 'gitty', no_merge_upstream: true }
     gitarro = Backend.new(@full_hash)
     puts gitarro.j_status
     gitarro.j_status = 'foo'
@@ -27,7 +27,8 @@ class BackendTest2 < Minitest::Test
   def test_run_script
     @full_hash = { repo: 'gino/gitarro', context: 'python-t', description:
                    'functional', test_file: 'test_data/script_ok.sh',
-                   file_type: '.sh', git_dir: 'gitty' }
+                   file_type: '.sh', git_dir: 'gitty',
+                   no_merge_upstream: true }
     gbex = TestExecutor.new(@full_hash)
     ck_files(gbex)
     test_file = 'nofile.txt'

--- a/tests/unit_tests/t_git_operation.rb
+++ b/tests/unit_tests/t_git_operation.rb
@@ -7,12 +7,11 @@ class GitarroGitop < Minitest::Test
   def test_gitop
     @full_hash = { repo: 'openSUSE/gitarro', context: 'python-t', description:
                    'functional', test_file: 'gino.sh', file_type: '.sh',
-                   git_dir: 'gitty', https: true }
+                   git_dir: 'gitty', https: true, pr_number: 5,
+                   no_merge_upstream: true }
     gb = Backend.new(@full_hash)
-    # crate fake object for internal class external repo
-    # FIXME: this could improved creating a full mock obj
-    pr = 'fake'
-    GitOp.new(gb.git_dir, pr, @full_hash)
+    gop = GitOp.new(gb.git_dir, @full_hash)
     puts gb.git_dir
+    gop.get_pr(@full_hash[:pr_number], 'master')
   end
 end


### PR DESCRIPTION
# **WARNING!!!! WARNING!!!! WARNING!!!!**
This is still an experimental feature.

It is already tested locally, but I would like to make more extensive testing before merging it.

Anyway it can be already reviewed, so feel free to have a look and comment anything strange you see. Feedback will be more than welcomed.

# **WARNING!!!! WARNING!!!! WARNING!!!!**

Second round, this time with retrocompatibility.

If ```--no_merge_upstream``` is present then gitarro will:

- Create an empty repository
- Fetch first commit from the PR
- First first commit from the reference branch and try to merge it
- Repeat with the second, third commits and so on, until merge is possible (or until it tries 100 times, and in that case either it considers there's no merge possible because the history was rewritten, or because the PR has too many commits).

The good thing about this change is that if the repository is big, gitarro will try fetch as less information possible.

As a way to avoid problems, gitarro now detects if a PR is not mergeable.

When that happens gitarro will mark the test as failed and remove the magic comment if needed at the PR, and will write a warning to the log.

If ```--no_merge_upstream``` is NOT present, gitarro will work as it worked before, but the PR mergeability detection will work.