### PR TITLE
Fix: Check repository dir apart from the base git dir

### DIFF
--- a/lib/gitarro/git_op.rb
+++ b/lib/gitarro/git_op.rb
@@ -47,11 +47,17 @@ class GitOp
   private
 
   def ck_or_clone_git
-    return if File.directory?(git_dir)
-    FileUtils.mkdir_p(git_dir)
+    git_repo_dir = git_dir + '/' + @options[:repo].split('/')[1]
+    return if File.directory?(git_repo_dir)
+    FileUtils.mkdir_p(git_dir) if File.directory?(git_dir)
     Dir.chdir git_dir
+    clone_repo
+  end
+
+  def clone_repo
     repo_url = "#{repo_protocol}#{@options[:repo]}.git"
     puts `git clone #{repo_url}`
+    exit 1 if $CHILD_STATUS.exitstatus.nonzero?
   end
 
   # this function merge the pr branch  into target branch,


### PR DESCRIPTION
This PR should fix an issue happening when certain repository has failed to be cloned.

On these cases, the following runs of `gitarro` would produce the next traceback during execution:

```
[manager-prs-susemanager-unittests] $ /bin/sh -xe /tmp/jenkins4518559196771098257.sh
+ /home/jenkins/bin/gitbot/gitarro.rb -r SUSE/spacewalk -c susemanager_unittests -d 'python backend pgsql unit test' -t /home/jenkins/jenkins-build/workspace/manager-prs-susemanager-unittests/gitbot_susemanager_unittests/spacewalk/susemanager-utils/testing/automation/susemanager-unittest.sh -u https://ci.suse.de/job/manager-prs-susemanager-unittests/4876/ -f susemanager/ -g /home/jenkins/jenkins-build/workspace/manager-prs-susemanager-unittests/gitbot_susemanager_unittests
/home/jenkins/bin/gitbot/lib/gitarro/git_op.rb:68:in `chdir': No such file or directory @ dir_chdir - spacewalk (Errno::ENOENT)
	from /home/jenkins/bin/gitbot/lib/gitarro/git_op.rb:68:in `rescue in goto_prj_dir'
	from /home/jenkins/bin/gitbot/lib/gitarro/git_op.rb:63:in `goto_prj_dir'
	from /home/jenkins/bin/gitbot/lib/gitarro/git_op.rb:28:in `merge_pr_totarget'
	from /home/jenkins/bin/gitbot/lib/gitarro/backend.rb:24:in `pr_test'
	from /home/jenkins/bin/gitbot/lib/gitarro/backend.rb:137:in `launch_test_and_setup_status'
	from /home/jenkins/bin/gitbot/lib/gitarro/backend.rb:121:in `reviewed_pr_test'
	from /home/jenkins/bin/gitbot/gitarro.rb:28:in `block in <main>'
	from /home/jenkins/bin/gitbot/gitarro.rb:12:in `each'
	from /home/jenkins/bin/gitbot/gitarro.rb:12:in `<main>'
...
```

The PR changes the behavior to actually check if the repository path exists. (not only the base git path).

/cc @MalloZup 
