### PR TITLE
LINT: fixup rubocop checkstyle

### DIFF
--- a/tests/spec/test_lib.rb
+++ b/tests/spec/test_lib.rb
@@ -4,8 +4,7 @@ require 'octokit'
 require 'English'
 
 # this might change
-GITARRO_BIN = '../../gitarro.rb'
-
+GITARRO_BIN = '../../gitarro.rb'.freeze
 
 # github octokit operation
 class GitRemoteOperations


### PR DESCRIPTION
Offenses:

tests/spec/test_lib.rb:7:15: C: [Corrected] Freeze mutable objects assigned to constants.
GITARRO_BIN = '../../gitarro.rb'
              ^^^^^^^^^^^^^^^^^^
tests/spec/test_lib.rb:9:1: C: [Corrected] Extra blank line detected.

14 files inspected, 2 offenses detected, 2 offenses corrected
