### PR TITLE
Print a boolean variable to show if gitarro found opened PRs or not

### DIFF
--- a/gitarro.rb
+++ b/gitarro.rb
@@ -9,7 +9,7 @@ require_relative 'lib/gitarro/backend'
 
 b = Backend.new
 prs = b.open_newer_prs
-exit 0 if b.pr_list_empty?(prs)
+exit 0 if prs.empty?
 
 prs.each do |pr|
   puts '=' * 30 + "\n" + "TITLE_PR: #{pr.title}, NR: #{pr.number}\n" + '=' * 30

--- a/lib/gitarro/backend.rb
+++ b/lib/gitarro/backend.rb
@@ -94,23 +94,13 @@ class Backend
     @gbexec = TestExecutor.new(@options)
   end
 
-  # Check if a PR list is empty
-  # If it is and we do want to consider the update time, return true
-  # Otherwise return false
-  def pr_list_empty?(prs)
-    prs.empty? && @options[:changed_since] >= 0 ? true : false
-  end
-
   # public method for get prs opened and matching the changed_since
   # condition
   def open_newer_prs
     prs = @client.pull_requests(@repo, state: 'open').select do |pr|
       pr_last_update_less_than(pr, @options[:changed_since])
     end
-    if pr_list_empty?(prs)
-      puts 'There are no Pull Requests opened or with changes newer than ' \
-           "#{options[:changed_since]} seconds"
-    end
+    print_pr_resume(prs)
     prs
   end
 
@@ -173,6 +163,20 @@ class Backend
   end
 
   private
+
+  # Show a message stating if there are opened PRs or not
+  def print_pr_resume(prs)
+    if prs.any?
+      puts "[PRS=#{prs.any?}] PRs opened. Analyzing them..."
+      return
+    end
+    if @options[:changed_since] >= 0
+      puts "[PRS=#{prs.any?}] No Pull Requests opened or with changes " \
+           "newer than #{options[:changed_since]} seconds"
+    else
+      puts "[PRS=#{prs.any?}] No Pull Requests opened"
+    end
+  end
 
   # Create a status for a PR
   def create_status(pr, status)

--- a/tests/spec/cmdline_spec.rb
+++ b/tests/spec/cmdline_spec.rb
@@ -99,16 +99,52 @@ describe 'cmdline secondary options' do
       expect(result).to be true
     end
   end
+end
 
-  describe '.changed_since' do
-    it 'gitarro should see at least PR #30 changed in the last 60 seconds' do
-      context = 'changed-since'
-      desc = 'changed-since'
+# secondary --changed_since
+describe 'cmdline changed-since' do
+  before(:each) do
+    @gitarrorepo = GIT_REPO
+    @rgit = GitRemoteOperations.new(@gitarrorepo)
+    @pr = @rgit.first_pr_open
+    @test = GitarroTestingCmdLine.new(@gitarrorepo)
+    # commit status
+    @comm_st = @rgit.commit_status(@pr)
+  end
+
+  describe '.changed_since_not_present' do
+    it "gitarro should see PR ##{PR_NUMBER} when --change_since not present" do
+      context = 'changed-since-not-present'
       pr = @rgit.pr_by_number(PR_NUMBER)
       comment = @rgit.create_comment(pr, "gitarro rerun #{context} !!!")
-      result = @test.changed_since_should_find(@comm_st, 60, context, desc)
+      result, output = @test.changed_since(@comm_st, -1, context)
       @rgit.delete_c(comment.id)
       expect(result).to be true
+      expect(output).to match(/^\[PRS=true\].*/)
+    end
+  end
+
+  describe '.changed_since_60' do
+    it "gitarro should see PR ##{PR_NUMBER} changed in the last 60 seconds" do
+      context = 'changed-since-60'
+      pr = @rgit.pr_by_number(PR_NUMBER)
+      comment = @rgit.create_comment(pr, "gitarro rerun #{context} !!!")
+      result, output = @test.changed_since(@comm_st, 60, context)
+      @rgit.delete_c(comment.id)
+      expect(result).to be true
+      expect(output).to match(/^\[PRS=true\].*/)
+    end
+  end
+
+  describe '.changed_since_zero' do
+    it 'gitarro should not see any PRs' do
+      context = 'changed-since-zero'
+      pr = @rgit.pr_by_number(PR_NUMBER)
+      comment = @rgit.create_comment(pr, "gitarro rerun #{context} !!!")
+      result, output = @test.changed_since(@comm_st, 0, context)
+      @rgit.delete_c(comment.id)
+      expect(result).to be true
+      expect(output).to match(/^\[PRS=false\].*/)
     end
   end
 end

--- a/tests/spec/test_lib.rb
+++ b/tests/spec/test_lib.rb
@@ -124,15 +124,16 @@ class GitarroTestingCmdLine
     true
   end
 
-  def changed_since_should_find(com_st, sec, context, desc)
+  def changed_since(com_st, sec, cont)
     `echo '#! /bin/bash' > #{valid_test}`
     `chmod +x #{valid_test}`
-    gitarro = "#{script} -r #{repo} -c #{context} -d #{desc} -g #{git_dir}" \
-                   " -t #{valid_test} -f #{ftype} -u #{url}" \
-                   " --changed_since #{sec}"
-    puts `ruby #{gitarro}`
-    return false if failed_status(com_st, context)
-    true
+    gitarro = "#{script} -r #{repo} -c #{cont} -d #{cont} -g #{git_dir}" \
+              " -t #{valid_test} -f #{ftype} -u #{url}"
+    changed_since_param = "--changed_since #{sec}" if sec >= 0
+    stdout = `ruby #{gitarro} #{changed_since_param}`
+    puts stdout
+    [failed_status(com_st, cont) && (sec > 0 || sec < 0) ? false : true,
+     stdout]
   end
 
   private

--- a/tests/unit_tests/t_backend.rb
+++ b/tests/unit_tests/t_backend.rb
@@ -47,24 +47,4 @@ class BackendTest2 < Minitest::Test
     assert_equal("'#{test_file}\' doesn't exists.Enter valid file, -t option",
                  ex.message)
   end
-
-  # this test consume rate_limiting
-  # in travis we skip them, because they are failing
-  # locally they are fine.
-  def test_get_all_prs
-    skip if ENV['TRAVIS']
-    @full_hash[:repo] = 'openSUSE/gitarro'
-    gitarro = Backend.new(@full_hash)
-    prs = gitarro.open_newer_prs
-    assert(true, prs.any?)
-  end
-
-  def test_get_no_prs
-    skip if ENV['TRAVIS']
-    @full_hash[:repo] = 'openSUSE/gitarro'
-    @full_hash[:changed_since] = 0
-    gitarro = Backend.new(@full_hash)
-    prs = gitarro.open_newer_prs
-    assert(0, prs.count)
-  end
 end


### PR DESCRIPTION
## What does this PR do?

Print a boolean variable to show if gitarro found opened PRs or not:

```
[PRS=FALSE] No Pull Requests opened or with changes newer than 60 seconds
```
```
[PRS=FALSE] No Pull Requests opened
```
```
[PRS=TRUE] Pull Requests opened. Analyzing them...
```

## What issues does this PR fix or reference?

 - https://github.com/openSUSE/gitarro/issues/71 (does NOT fix it completely, we still need to verify if there are some cases when we exit with != 0 when there are no errors)

## Tests written? 

Yes. Rspec.

## Workflow:

Followed