### PR TITLE
Do not exit 1 when --check is enabled, but show a message

### DIFF
--- a/lib/gitarro/backend.rb
+++ b/lib/gitarro/backend.rb
@@ -108,7 +108,8 @@ class Backend
   def retrigger_check(pr)
     return unless retrigger_needed?(pr)
     create_status(pr, 'pending')
-    exit 1 if @check
+    print_test_required
+    exit 0 if @check
     launch_test_and_setup_status(pr) == 'success' ? exit(0) : exit(1)
   end
 
@@ -116,6 +117,7 @@ class Backend
   def trigger_by_pr_number(pr)
     return false if @pr_number.nil? || @pr_number != pr.number
     puts "Got triggered by PR_NUMBER OPTION, rerunning on #{@pr_number}"
+    print_test_required
     launch_test_and_setup_status(pr)
   end
 
@@ -133,6 +135,7 @@ class Backend
     return if empty_files_changed_by_pr(pr)
     # gb.check is true when there is a job running as scheduler
     # which doesn't execute the test but trigger another job
+    print_test_required
     return false if @check
     launch_test_and_setup_status(pr)
   end
@@ -144,7 +147,9 @@ class Backend
                         pending_pr(comm_st) == true
     return true if changelog_active(pr, comm_st)
     return false unless pr_all_files_type(pr.number, @file_type).any?
-    @check ? exit(1) : launch_test_and_setup_status(pr)
+    print_test_required
+    exit(0) if @check
+    launch_test_and_setup_status(pr)
   end
 
   # this function will check if the PR contains in comment the magic word
@@ -176,6 +181,10 @@ class Backend
     else
       puts "[PRS=#{prs.any?}] No Pull Requests opened"
     end
+  end
+
+  def print_test_required
+    puts '[TESTREQUIRED=true] PR requires test'
   end
 
   # Create a status for a PR

--- a/tests/spec/cmdline_spec.rb
+++ b/tests/spec/cmdline_spec.rb
@@ -148,3 +148,39 @@ describe 'cmdline changed-since' do
     end
   end
 end
+
+# Testing checks
+describe 'testing checks' do
+  before(:each) do
+    @gitarrorepo = GIT_REPO
+    @rgit = GitRemoteOperations.new(@gitarrorepo)
+    @pr = @rgit.first_pr_open
+    @test = GitarroTestingCmdLine.new(@gitarrorepo)
+    # commit status
+    @comm_st = @rgit.commit_status(@pr)
+  end
+
+  describe '.pr_requiring_test' do
+    it "gitarro should see PR ##{PR_NUMBER} as requiring test" do
+      context = 'pr-should-retest'
+      pr = @rgit.pr_by_number(PR_NUMBER)
+      comment = @rgit.create_comment(pr, "gitarro rerun #{context} !!!")
+      result, output = @test.changed_since(@comm_st, 60, context)
+      @rgit.delete_c(comment.id)
+      expect(result).to be true
+      expect(output).to match(/^\[TESTREQUIRED=true\].*/)
+    end
+  end
+
+  describe '.pr_not_requiring_test' do
+    it "gitarro should see PR ##{PR_NUMBER} as not requiring test" do
+      context = 'pr-should-not-retest'
+      pr = @rgit.pr_by_number(PR_NUMBER)
+      comment = @rgit.create_comment(pr, "Updating PR for #{context} !!!")
+      result, output = @test.changed_since(@comm_st, 60, context)
+      @rgit.delete_c(comment.id)
+      expect(result).to be true
+      expect(output).not_to match(/^\[TESTREQUIRED=true\].*/)
+    end
+  end
+end

--- a/tests/spec/test_lib.rb
+++ b/tests/spec/test_lib.rb
@@ -86,9 +86,9 @@ class GitarroTestingCmdLine
     end
     puts `ruby #{gitarro} -C`
     # with check we have -1 has value ( used for retrigger)
-    return false if $CHILD_STATUS.exitstatus.zero?
+    return true if $CHILD_STATUS.exitstatus.zero?
     puts `ruby #{gitarro}`
-    true
+    false
   end
 
   def changelog_should_fail(com_st)


### PR DESCRIPTION
## What does this PR do?

Do not exit 1 when --check is enabled, but show a message.

## What issues does this PR fix or reference?

 - https://github.com/openSUSE/gitarro/issues/71

## Tests written? 

Yes, two now rspec.

## Workflow:

Followed