### PR TITLE
Fix guard clause syntax

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ task default: %i[lint reek test buildgem]
 class RspecConfiguration
   def self.check_conf_file
     return true if File.file?('.rspec.yml')
+
     puts '*******************************'
     puts 'Create a .rspec.yml file first'
     puts 'repo and pr_number as variables'

--- a/gitarro.rb
+++ b/gitarro.rb
@@ -15,10 +15,12 @@ prs.each do |pr|
   puts '=' * 30 + "\n" + "TITLE_PR: #{pr.title}, NR: #{pr.number}\n" + '=' * 30
   # check if prs contains the branch given otherwise just break
   next unless b.pr_equal_spefic_branch?(pr)
+
   # this check the last commit state, catch for review or not reviewd status.
   comm_st = b.client.status(b.repo, pr.head.sha)
   # pr number trigger.
   break if b.triggered_by_pr_number?
+
   # retrigger if magic word found
   b.retrigger_check(pr)
   # 0) do test for unreviewed pr

--- a/lib/gitarro/backend.rb
+++ b/lib/gitarro/backend.rb
@@ -162,6 +162,7 @@ class Backend
   def pr_equal_spefic_branch?(pr)
      return true if @branch.nil?
      return true if @branch == pr.base.ref 
+
      puts "branch \"#{pr.base.ref}\" should match github-branch \"#{@branch}\" (given) !!!"
      puts "skipping tests !!!"
      false
@@ -180,6 +181,7 @@ class Backend
   # public for retrigger the test
   def retrigger_check(pr)
     return unless retrigger_needed?(pr)
+
     create_status(pr, 'pending')
     print_test_required
     exit 0 if @check
@@ -188,7 +190,8 @@ class Backend
 
   # public always rerun tests against the pr number if this exists
   def triggered_by_pr_number?
-    return false if @pr_number.nil? 
+    return false if @pr_number.nil?
+
     pr_on_number = @client.pull_request(@repo, @pr_number) 
     puts "Got triggered by PR_NUMBER OPTION, rerunning on #{@pr_number}"
     print_test_required
@@ -197,12 +200,15 @@ class Backend
 
   def unreviewed_new_pr?(pr, comm_st)
     return unless commit_is_unreviewed?(comm_st)
+
     pr_all_files_type(pr.number, @file_type)
     return if empty_files_changed_by_pr?(pr)
+
     # gb.check is true when there is a job running as scheduler
     # which doesn't execute the test but trigger another job
     print_test_required
     return false if @check
+
     launch_test_and_setup_status(pr)
   end
 
@@ -212,6 +218,7 @@ class Backend
     return false unless context_present?(comm_st) == false ||
                         pending_pr?(comm_st)
     return false unless pr_all_files_type(pr.number, @file_type).any?
+
     print_test_required
     exit(0) if @check
     launch_test_and_setup_status(pr)
@@ -297,6 +304,7 @@ class Backend
   def retrigger_needed?(pr)
     # we want redo sometimes tests
     return false unless retriggered_by_comment?(pr.number, @context)
+
     # if check is set, the comment in the trigger job will be del.
     # so setting it to pending, it will be remembered
     pr_all_files_type(pr.number, @file_type).any?

--- a/lib/gitarro/git_op.rb
+++ b/lib/gitarro/git_op.rb
@@ -67,6 +67,7 @@ class GitOp
     `git pull origin #{upstream}`
     `git checkout -b #{pr_fix}#{pr_branch} origin/#{pr_branch}`
     return if $CHILD_STATUS.exitstatus.zero?
+
     # if it fails the PR contain a forked external repo
     repo_external.checkout_into
   end
@@ -82,6 +83,7 @@ class GitOp
   def ck_or_clone_git
     git_repo_dir = git_dir + '/' + @options[:repo].split('/')[1]
     return if File.directory?(git_repo_dir)
+
     FileUtils.mkdir_p(git_dir) unless File.directory?(git_dir)
     Dir.chdir git_dir
     clone_repo

--- a/lib/gitarro/opt_parser.rb
+++ b/lib/gitarro/opt_parser.rb
@@ -136,6 +136,7 @@ class OptParserInternal
 
   def ck_mandatory_option(option)
     return unless @options[option.to_sym].nil?
+
     raise_incorrect_syntax("option --#{option} not found")
   end
 

--- a/tests/spec/rspec_helper.rb
+++ b/tests/spec/rspec_helper.rb
@@ -9,6 +9,7 @@ class SetupRspec
     git_repo = ENV['repo']
     no_repo = 'No gitarro repo was given! use your forked repo'
     raise ArgumentError, no_repo if git_repo.nil?
+
     git_repo
   end
 
@@ -16,6 +17,7 @@ class SetupRspec
     number = ENV['pr_num']
     no_pr = 'No pr Number where to run tests was given'
     raise ArgumentError, no_pr if number.nil?
+
     number
   end
 end

--- a/tests/spec/test_lib.rb
+++ b/tests/spec/test_lib.rb
@@ -71,6 +71,7 @@ module BasicTests
     # with check we have -1 has value ( used for retrigger)
     puts `ruby #{gitarro}`
     return true if $CHILD_STATUS.exitstatus.zero?
+
     false
   end
 
@@ -109,6 +110,7 @@ class GitarroTestingCmdLine
       puts `ruby #{gitarro}`
     end
     raise 'GITARRO SHOULDNT FAIL' if failed_status(comm_st, cont)
+
     File.file?('/tmp/foo2')
   end
 
@@ -127,6 +129,7 @@ class GitarroTestingCmdLine
   
     puts `ruby #{gitarro}`
     raise 'GITARRO SHOULDNT FAIL' if failed_status(comm_st, cont)
+
     true
   end
 

--- a/tools/scripts/changelog_test.rb
+++ b/tools/scripts/changelog_test.rb
@@ -21,6 +21,7 @@ class ChangelogTests
   def changelog_modified?
     # if the pr contains changes on .changes file, test ok
     return true if pr_contains_changelog? || magic_comment?
+
     false
   end
 


### PR DESCRIPTION
## What does this PR do?

Fix guard clause syntax, as new rubocop version at Travis is complaining about the lack of empty lines after them:
```
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/gitarro/backend.rb:320:5: C: Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
    return false unless retriggered_by_comment?(pr.number, @context)
```

## What issues does this PR fix or reference?

 - https://github.com/openSUSE/gitarro/pull/121#issuecomment-424445954

## Tests written? 

No, just syntax fixing, adding empty lines.
