### PR TITLE
Version 0.1.79

### DIFF
--- a/gem/gitarro.gemspec
+++ b/gem/gitarro.gemspec
@@ -1,6 +1,6 @@
 require 'date'
 
-GITARRO_VERSION = '0.1.78'.freeze
+GITARRO_VERSION = '0.1.79'.freeze
 GITARRO_TODAY = Date.today.strftime('%Y-%m-%d')
 Gem::Specification.new do |s|
   s.name = 'gitarro'


### PR DESCRIPTION
## What does this PR do?

Push the version to 0.1.79 as 0.1.78 was already released to rubygems.org.