### PR TITLE
Fix triggered_by_pr_number and push version to 0.1.81

### DIFF
--- a/gem/gitarro.gemspec
+++ b/gem/gitarro.gemspec
@@ -1,6 +1,6 @@
 require 'date'
 
-GITARRO_VERSION = '0.1.80'.freeze
+GITARRO_VERSION = '0.1.81'.freeze
 GITARRO_TODAY = Date.today.strftime('%Y-%m-%d')
 Gem::Specification.new do |s|
   s.name = 'gitarro'

--- a/lib/gitarro/backend.rb
+++ b/lib/gitarro/backend.rb
@@ -214,7 +214,7 @@ class Backend
     pr_on_number = @client.pull_request(@repo, @pr_number) 
     puts "Got triggered by PR_NUMBER OPTION, rerunning on #{@pr_number}"
     print_test_required
-    gbexec.export_pr_data(pr)
+    gbexec.export_pr_data(pr_on_number)
     launch_test_and_setup_status(pr_on_number) == 'success' ? exit(0) : exit(1)
   end
 


### PR DESCRIPTION
## What does this PR do?

Fix triggered_by_pr_number and push version to 0.1.81.

`pr` variable do not exist at `triggered_by_pr_number`