### PR TITLE
Exit directly in function definition

### DIFF
--- a/lib/gitarro/backend.rb
+++ b/lib/gitarro/backend.rb
@@ -204,7 +204,7 @@ class Backend
     print_test_required
     gbexec.export_pr_data(pr)
     exit 0 if @check
-    launch_test_and_setup_status(pr) == 'success' ? exit(0) : exit(1)
+    launch_test_and_setup_status(pr)
   end
 
   # public always rerun tests against the pr number if this exists
@@ -215,7 +215,7 @@ class Backend
     puts "Got triggered by PR_NUMBER OPTION, rerunning on #{@pr_number}"
     print_test_required
     gbexec.export_pr_data(pr_on_number)
-    launch_test_and_setup_status(pr_on_number) == 'success' ? exit(0) : exit(1)
+    launch_test_and_setup_status(pr_on_number)
   end
 
   def unreviewed_new_pr?(pr, comm_st)
@@ -230,7 +230,7 @@ class Backend
     gbexec.export_pr_data(pr)
     return false if @check
 
-    launch_test_and_setup_status(pr) == 'success' ? exit(0) : exit(1)
+    launch_test_and_setup_status(pr)
   end
 
   def reviewed_pr?(comm_st, pr)
@@ -243,7 +243,7 @@ class Backend
     print_test_required
     gbexec.export_pr_data(pr)
     exit(0) if @check
-    launch_test_and_setup_status(pr) == 'success' ? exit(0) : exit(1)
+    launch_test_and_setup_status(pr)
   end
 
   # this function will check if the PR contains in comment the magic word
@@ -294,7 +294,7 @@ class Backend
     # set status
     create_status(pr, test_status)
     # return status for other functions
-    test_status
+    test_status == 'success' ? exit(0) : exit(1)
   end
 
   # check all files of a Prs Number if they are a specific type


### PR DESCRIPTION
## What does this PR do?
Refactor launch_test_and_setup_status function. Instead of exiting where this function was called, the exit method is now inside it.

## What issues does this PR fix or reference?

 - https://github.com/openSUSE/gitarro/issues/139

## Tests written? 
No, just syntax fixing.
