### PR TITLE
Replace the each loop for map

### DIFF
--- a/lib/gitarro/backend.rb
+++ b/lib/gitarro/backend.rb
@@ -119,10 +119,7 @@ class TestExecutor
 
   def export_pr_data_to_json_file(pr)
     pr = pr.to_hash
-    pr[:files] = []
-    @client.pull_request_files(@repo, pr[:number]).each do |github_file|
-        pr[:files].push(github_file.to_hash)
-    end
+    pr[:files] = @client.pull_request_files(@repo, pr[:number]).map(&:to_h)
     File.open('.gitarro_pr.json', 'w') do |file|
        file.write(JSON.generate(pr))
     end


### PR DESCRIPTION
It close #143

In order to simplify the code we replace the each loop for a map one because we just need to add the elements on a new array of hashes