### PR TITLE
[6346] Allow skipping changelog test from description

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -55,11 +55,15 @@ Layout/TrailingWhitespace:
 # ExcludedMethods: refine
 Metrics/BlockLength:
   Max: 39
+  Exclude:
+    - 'tests/spec/secondary2_spec.rb'
 
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
   Max: 112
+  Exclude:
+  - 'lib/gitarro/backend.rb'
 
 # Offense count: 3
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It can run on any system that is able to use ruby and [octokit](https://github.c
 
 1. Setup the netrc file
     ```shell
-    GITHUB_USER=INSERT GITHUB_PWD_OR_TOKEN=foo echo "machine api.github.com login $GITHUB_USER password $GITUB_PWD_OR_TOKEN" > /~.netrc
+    GITHUB_USER=INSERT GITHUB_PWD_OR_TOKEN=foo echo "machine api.github.com login $GITHUB_USER password $GITUB_PWD_OR_TOKEN" > ~/.netrc
     sudo chmod 0600 ~/.netrc
     ```
 
@@ -44,7 +44,7 @@ It can run on any system that is able to use ruby and [octokit](https://github.c
 
     ```shell
     YOUR_GITHUB_PROJECT="MalloZup/gitarro"
-    gitarro.rb -r $YOUR_GITHUB_PROJECT -c "ruby-test" -t /tmp/tests.sh --https"
+    gitarro.rb -r $YOUR_GITHUB_PROJECT -c "ruby-test" -t /tmp/tests.sh --https
     ```
 
 ## Authors

--- a/doc/ADVANCED.md
+++ b/doc/ADVANCED.md
@@ -26,24 +26,24 @@ Here just an example:
 
 ## Instructions
 
-In order to retrigger a specific test, you need to add a comment to the PR.
+In order to retrigger a specific test, you need to add a comment to the PR or add a checkbox into the description of the PR.
 
 **PLESE NOTE**: gitarro will delete the comment where you write the retriggering command,
 so make sure that you use a separate comment for this.
 
 ### Syntax
 
+#### Using a comment
 ```shell
 gitarro rerun <test_name> !!!
 ```
-
 Notice that there is a space and three exclamation marks (`!!!`) after the test name. This is required for the command to work.
 
-## Examples
+##### Examples
 
 In this examples you want to rerun a test called gitarro-magic.
 
-### Valid examples:
+###### Valid examples:
 
 - `gitarro rerun gitarro-magic !!!`
 
@@ -55,10 +55,9 @@ In this examples you want to rerun a test called gitarro-magic.
 
 - `I discovered a bug so I need to run tests again, gitarro rerun gitarro-magic !!!!!!!`
 
-
   It will work since there is a space and at least three exclamation marks after the test name, but **the whole comment will be removed** and the developer will loose it.
 
-### Invalid examples:
+###### Invalid examples:
 
 - `gitarro rerun gitarro-magic !`
 
@@ -67,6 +66,32 @@ In this examples you want to rerun a test called gitarro-magic.
 - `gitarro rerun gitarro-magic2 !!!!!!!`
 
   It will not work since there is a space and at least three exclamation marks after the test name, but the test name itself is incorrect.
+
+#### Using a checkbox
+```shell
+- [x] Re-run test "<test_name>"
+```
+
+##### Examples
+
+In this examples you want to rerun a test called gitarro-magic.
+
+###### Valid examples:
+
+- `- [x] Re-run test "gitarro-magic"`
+
+  It will trigger the test and uncheck automatically, even if the test fails
+  
+- `- [x] Re-run test "gitarro-magic" (I discovered a bug so I need to run tests again)`
+
+  It will work since since is matching the regular expression
+
+###### Invalid examples:
+
+- `- [x] Re-run test gitarro-magic`
+
+  It will not work since is not matching the regular expression
+
 
 ## Check for PRs
 

--- a/gem/gitarro.gemspec
+++ b/gem/gitarro.gemspec
@@ -26,4 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.6'
   s.add_development_dependency 'rubocop', '~> 0.49'
   s.add_development_dependency 'rubocop-rspec', '~> 1.19'
+  s.metadata = {
+	   'changelog_uri' => 'https://github.com/openSUSE/gitarro/blob/master/CHANGELOG.md'
+  }
 end

--- a/lib/gitarro/backend.rb
+++ b/lib/gitarro/backend.rb
@@ -178,7 +178,7 @@ class Backend
      return true if @branch == pr.base.ref 
 
      puts "branch \"#{pr.base.ref}\" should match github-branch \"#{@branch}\" (given) !!!"
-     puts "skipping tests !!!"
+     puts 'skipping tests !!!'
      false
   end
 
@@ -249,12 +249,25 @@ class Backend
     # a pr contain always a comments, cannot be nil
     @client.issue_comments(@repo, pr_number).each do |com|
       # delete comment otherwise it will be retrigger infinetely
-      if com.body.include? magic_word_trigger
-        @client.delete_comment(@repo, com.id)
-        return true
-      end
+      next unless com.body.include? magic_word_trigger
+
+      puts "Re-run test \"#{context}\""
+      @client.delete_comment(@repo, com.id)
+      return true
     end
     false
+  end
+
+  # this function will check if the PR contains a checkbox
+  # for retrigger all the tests.
+  def retriggered_by_checkbox?(pr, context)
+    return false unless pr.body.include? "[x] Re-run test \"#{context}\""
+
+    puts "Re-run test \"#{context}\""
+    new_pr_body = pr.body.gsub("[x] Re-run test \"#{context}\"",
+                               "[ ] Re-run test \"#{context}\"")
+    @client.update_pull_request(@repo, pr.number, body: new_pr_body)
+    true
   end
 
   private
@@ -321,7 +334,8 @@ class Backend
 
   def retrigger_needed?(pr)
     # we want redo sometimes tests
-    return false unless retriggered_by_comment?(pr.number, @context)
+    return false unless retriggered_by_checkbox?(pr, @context) ||
+                        retriggered_by_comment?(pr, @context)
 
     # if check is set, the comment in the trigger job will be del.
     # so setting it to pending, it will be remembered

--- a/tests/spec/secondary2_spec.rb
+++ b/tests/spec/secondary2_spec.rb
@@ -9,7 +9,7 @@ describe 'secondary2 features' do
   let(:test) { GitarroTestingCmdLine.new(gitarrorepo, '/tmp/bar') }
   let(:comm_st) { rgit.commit_status(pr) }
 
-  it 'gitarro should see PR requiring test' do
+  it 'gitarro should see PR requiring test through a comment' do
     context = 'pr-should-retest'
     comment = rgit.create_comment(pr, "gitarro rerun #{context} !!!")
     result, output = test.changed_since(comm_st, 60, context)
@@ -18,11 +18,27 @@ describe 'secondary2 features' do
     expect(output).to match(/^\[TESTREQUIRED=true\].*/)
   end
 
-  it 'gitarro should see PR as not requiring test' do
+  it 'gitarro should see PR as not requiring test through a comment' do
     context = 'pr-should-not-retest'
     comment = rgit.create_comment(pr, "Updating PR for #{context} !!!")
     result, output = test.changed_since(comm_st, 60, context)
     rgit.delete_c(comment.id)
+    expect(result).to be true
+    expect(output).not_to match(/^\[TESTREQUIRED=true\].*/)
+  end
+
+  it 'gitarro should see PR requiring test through a checkbox' do
+    context = 'pr-should-retest'
+    rgit.change_description(pr, "[x] Re-run test \"#{context}\"")
+    result, output = test.changed_since(comm_st, 60, context)
+    expect(result).to be true
+    expect(output).to match(/^\[TESTREQUIRED=true\].*/)
+  end
+
+  it 'gitarro should see PR as not requiring test through a checkbox' do
+    context = 'pr-should-not-retest'
+    rgit.change_description(pr, "[ ] Re-run test \"#{context}\"")
+    result, output = test.changed_since(comm_st, 60, context)
     expect(result).to be true
     expect(output).not_to match(/^\[TESTREQUIRED=true\].*/)
   end

--- a/tests/spec/test_lib.rb
+++ b/tests/spec/test_lib.rb
@@ -32,6 +32,10 @@ class GitRemoteOperations
     client.add_comment(repo, pr.number, comment)
   end
 
+  def change_description(pr, description)
+    client.update_pull_request(repo, pr.number, body: description)
+  end
+
   def delete_c(comment_id)
     client.delete_comment(repo, comment_id)
   end

--- a/tools/scripts/changelog_test.rb
+++ b/tools/scripts/changelog_test.rb
@@ -30,7 +30,7 @@ class ChangelogTests
 
   def changelog_modified?
     # if the pr contains changes on .changes file, test ok
-    return true if pr_contains_changelog? || magic_comment?
+    return true if pr_contains_changelog? || no_changelog_needed? || magic_comment?
 
     false
   end
@@ -41,6 +41,16 @@ class ChangelogTests
     @client.issue_comments(repo, pr_num).any? do |com|
       com.body.include?('no changelog needed')
     end
+  end
+
+  def no_changelog_needed?
+    return false if pr_num.nil?
+
+    pr = @client.pull_request(repo, pr_num)
+    return true unless pr.body.include? '[x] No changelog needed'
+
+    puts 'Skipping changelog update verification'
+    false
   end
 
   def pr_contains_changelog?


### PR DESCRIPTION
## What does this PR do?

Related to Task: https://github.com/SUSE/spacewalk/issues/6346

It changes the way we re-run tests and we specify if changelog must be checked. we will use the checkboxes you see bellow: 

- [ ] Re-run test "changelog_test"

- [ ] No changelog needed

In the first case, gitarro will change from checked to unchecked after re-run th test.