### PR TITLE
Feature/basic check

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It can run on any system that is able to use ruby and [octokit](https://github.c
 
 1. Setup the netrc file
     ```shell
-    GITHUB_USER=INSERT GITHUB_PWD_OR_TOKEN=foo echo "machine api.github.com login $GITHUB_USER password $GITUB_PWD_OR_TOKEN" > /~.netrc
+    GITHUB_USER=INSERT GITHUB_PWD_OR_TOKEN=foo echo "machine api.github.com login $GITHUB_USER password $GITUB_PWD_OR_TOKEN" > ~/.netrc
     sudo chmod 0600 ~/.netrc
     ```
 
@@ -44,7 +44,7 @@ It can run on any system that is able to use ruby and [octokit](https://github.c
 
     ```shell
     YOUR_GITHUB_PROJECT="MalloZup/gitarro"
-    gitarro.rb -r $YOUR_GITHUB_PROJECT -c "ruby-test" -t /tmp/tests.sh --https"
+    gitarro.rb -r $YOUR_GITHUB_PROJECT -c "ruby-test" -t /tmp/tests.sh --https
     ```
 
 ## Authors

--- a/doc/BASICS.md
+++ b/doc/BASICS.md
@@ -30,6 +30,7 @@ Optional options:
     -f, --file '.py'                 pr_file type to filter/trigger the test against: .py, .rb
     -d, --description 'DESCRIPTION'  Test decription
     -C, --check                      Check if there is any PR requiring a test, but do not run it.
+    -B, --basiccheck                 Return the amount of PRs requiring a test, but do not run it.
     -u, --url 'TARGET_URL'           Specify the URL to append to add to the GitHub review. Usually you                                   will use an URL to the Jenkins build log.
     -P  --PR 'NUMBER'                Specify the PR number instead of checking all of them. This will                                     force gitarro to run the against a specific PR number,even if it is                                  not needed (useful for using Jenkins with GitHub webhooks).
         --https                      If present, use https instead of ssh for git operations

--- a/gitarro.rb
+++ b/gitarro.rb
@@ -11,6 +11,18 @@ b = Backend.new
 prs = b.open_newer_prs
 exit 0 if prs.empty?
 
+if b.options[:basiccheck]
+  prs.each do |pr|
+    comm_st = b.client.status(b.repo, pr.head.sha)
+    if silenced do b.commit_is_unreviewed?(comm_st) || b.retriggered_by_checkbox?(pr, 'all') end
+      puts "PR #{pr.number} has a pending test."
+      b.print_test_required
+      break
+    end
+  end
+  exit 0
+end
+
 prs.each do |pr|
   puts '=' * 30 + "\n" + "TITLE_PR: #{pr.title}, NR: #{pr.number}\n" + '=' * 30
   # check if prs contains the branch given otherwise just break
@@ -19,6 +31,7 @@ prs.each do |pr|
   # this check the last commit state, catch for review or not reviewd status.
   comm_st = b.client.status(b.repo, pr.head.sha)
   # pr number trigger.
+  #TODO: Why we are doing another request to get the PR if we can pass it by parameter?
   break if b.triggered_by_pr_number?
 
   # retrigger if magic word found

--- a/lib/gitarro/opt_parser.rb
+++ b/lib/gitarro/opt_parser.rb
@@ -37,6 +37,11 @@ module OptionalOptions
     opt.on('-C', '--check', desc) { |check| @options[:check] = check }
   end
 
+  def basic_check_opt(opt)
+    desc = 'Return the amount of PRs requiring a test, but do not run it.'
+    opt.on('-B', '--basiccheck', desc) { |basiccheck| @options[:basiccheck] = basiccheck }
+  end
+
   def no_shallow(opt)
     desc = 'If enabled, gitarro will not use git shallow clone'
     opt.on('--noshallow', desc) { |noshallow| @options[:noshallow] = noshallow }
@@ -106,6 +111,7 @@ module OptionalOptions
     opt.separator "\n Optional options:"
     desc_opt(opt)
     check_opt(opt)
+    basic_check_opt(opt)
     branch_opt(opt)
     no_shallow(opt)
     file_opt(opt)

--- a/tools/scripts/changelog_test.rb
+++ b/tools/scripts/changelog_test.rb
@@ -30,18 +30,28 @@ class ChangelogTests
 
   def changelog_modified?
     # if the pr contains changes on .changes file, test ok
-    return true if pr_contains_changelog? || magic_comment?
+    return true if pr_contains_changelog? || no_changelog_needed? || magic_comment?
 
     false
   end
 
   private
 
+  #TODO: To be deprecated when no_changelog_needed? is welcomed by users
   def magic_comment?
     @client.issue_comments(repo, pr_num).any? do |com|
       com.body.include?('no changelog needed')
     end
   end
+
+  def no_changelog_needed?
+    return false if pr_num.nil?
+    pr = @client.pull_request(repo, pr_num)
+    return true unless pr.body.include? "[x] No changelog needed"
+    puts "Skipping changelog update verification"
+    false
+  end
+
 
   def pr_contains_changelog?
     pr_file_have_changelog?(@client.pull_request_files(repo, pr_num))


### PR DESCRIPTION
## What does this PR do?
This new option will allow us to implement the first step to reduce the amount of poolling we do to GitHub in Jenkins CI. 

https://github.com/SUSE/spacewalk/issues/6411

The idea is to take advantage of the return code, which will let us know if exist any pending pr, no matter the context or branch, to have an unique Jenkins pipeline pooling to github periodically, and once we have a pending PR, only then execute all the pipelines to run the different checks of PRs. Hopefully we will reduce drastically the number of job executions, and we will have a cleaner history in the childs, as allways they will run, they will have a pending pr to process.

Please @MalloZup @juliogonzalez take a look on that one. Thanks!