### PR TITLE
Hotfix a mistake in params on retriggered_by_comment method

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It can run on any system that is able to use ruby and [octokit](https://github.c
 
 1. Setup the netrc file
     ```shell
-    GITHUB_USER=INSERT GITHUB_PWD_OR_TOKEN=foo echo "machine api.github.com login $GITHUB_USER password $GITUB_PWD_OR_TOKEN" > ~/.netrc
+    GITHUB_USER=INSERT GITHUB_PWD_OR_TOKEN=foo echo "machine api.github.com login $GITHUB_USER password $GITHUB_PWD_OR_TOKEN" > ~/.netrc
     sudo chmod 0600 ~/.netrc
     ```
 

--- a/gem/gitarro.gemspec
+++ b/gem/gitarro.gemspec
@@ -1,6 +1,6 @@
 require 'date'
 
-GITARRO_VERSION = '0.1.82'.freeze
+GITARRO_VERSION = '0.1.83'.freeze
 GITARRO_TODAY = Date.today.strftime('%Y-%m-%d')
 Gem::Specification.new do |s|
   s.name = 'gitarro'

--- a/lib/gitarro/backend.rb
+++ b/lib/gitarro/backend.rb
@@ -244,10 +244,10 @@ class Backend
 
   # this function will check if the PR contains in comment the magic word
   # # for retrigger all the tests.
-  def retriggered_by_comment?(pr_number, context)
+  def retriggered_by_comment?(pr, context)
     magic_word_trigger = "gitarro rerun #{context} !!!"
     # a pr contain always a comments, cannot be nil
-    @client.issue_comments(@repo, pr_number).each do |com|
+    @client.issue_comments(@repo, pr.number).each do |com|
       # delete comment otherwise it will be retrigger infinetely
       next unless com.body.include? magic_word_trigger
 


### PR DESCRIPTION
## What does this PR do?

Hotfix a mistake in params on retriggered_by_comment method.

As we added that method (to include both ways of trigger a test), The signature of the method was changed, so now we are passing the PR and we need then to specify the pr.number for issue_comments method.
```
  def retrigger_needed?(pr)
    # we want redo sometimes tests
    return false unless retriggered_by_checkbox?(pr, @context) ||
                        retriggered_by_comment?(pr, @context)
```