### PR TITLE
Fix pending status using check parameter and add a "skipping comment" in checkbox when the test doesn't apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog Gitarro
 
+## 0.1.84
+
+- Fix the bug discussed in #166
+- Add a comment after unmark a rerun test checkbox, in case the test does not apply
+
 ## 0.1.83
 
 - Hot-fix 0.1.82, retriggered_by_comment had a change in the signature

--- a/gem/gitarro.gemspec
+++ b/gem/gitarro.gemspec
@@ -1,6 +1,6 @@
 require 'date'
 
-GITARRO_VERSION = '0.1.83'.freeze
+GITARRO_VERSION = '0.1.84'.freeze
 GITARRO_TODAY = Date.today.strftime('%Y-%m-%d')
 Gem::Specification.new do |s|
   s.name = 'gitarro'

--- a/gitarro.rb
+++ b/gitarro.rb
@@ -8,6 +8,8 @@ require_relative 'lib/gitarro/git_op'
 require_relative 'lib/gitarro/backend'
 
 b = Backend.new
+exit 0 if b.triggered_by_pr_number?
+
 prs = b.open_newer_prs
 exit 0 if prs.empty?
 
@@ -18,8 +20,6 @@ prs.each do |pr|
 
   # this check the last commit state, catch for review or not reviewd status.
   comm_st = b.client.status(b.repo, pr.head.sha)
-  # pr number trigger.
-  break if b.triggered_by_pr_number?
 
   # retrigger if magic word found
   b.retrigger_check(pr)

--- a/tests/spec/secondary2_spec.rb
+++ b/tests/spec/secondary2_spec.rb
@@ -10,7 +10,7 @@ describe 'secondary2 features' do
   let(:comm_st) { rgit.commit_status(pr) }
 
   it 'gitarro should see PR requiring test through a comment' do
-    context = 'pr-should-retest'
+    context = 'pr-should-retest-through-comment'
     comment = rgit.create_comment(pr, "gitarro rerun #{context} !!!")
     result, output = test.changed_since(comm_st, 60, context)
     rgit.delete_c(comment.id)
@@ -19,7 +19,7 @@ describe 'secondary2 features' do
   end
 
   it 'gitarro should see PR as not requiring test through a comment' do
-    context = 'pr-should-not-retest'
+    context = 'pr-should-not-retest-through-comment'
     comment = rgit.create_comment(pr, "Updating PR for #{context} !!!")
     result, output = test.changed_since(comm_st, 60, context)
     rgit.delete_c(comment.id)
@@ -28,17 +28,19 @@ describe 'secondary2 features' do
   end
 
   it 'gitarro should see PR requiring test through a checkbox' do
-    context = 'pr-should-retest'
-    rgit.change_description(pr, "[x] Re-run test \"#{context}\"")
+    context = 'pr-should-retest-through-checkbox'
+    rgit.change_description(pr, "- [x] Re-run test \"#{context}\"")
     result, output = test.changed_since(comm_st, 60, context)
+    rgit.change_description(pr, '')
     expect(result).to be true
     expect(output).to match(/^\[TESTREQUIRED=true\].*/)
   end
 
   it 'gitarro should see PR as not requiring test through a checkbox' do
-    context = 'pr-should-not-retest'
-    rgit.change_description(pr, "[ ] Re-run test \"#{context}\"")
+    context = 'pr-should-not-retest-through-checkbox'
+    rgit.change_description(pr, "- [ ] Re-run test \"#{context}\"")
     result, output = test.changed_since(comm_st, 60, context)
+    rgit.change_description(pr, '')
     expect(result).to be true
     expect(output).not_to match(/^\[TESTREQUIRED=true\].*/)
   end

--- a/tools/scripts/changelog_test.rb
+++ b/tools/scripts/changelog_test.rb
@@ -30,7 +30,7 @@ class ChangelogTests
 
   def changelog_modified?
     # if the pr contains changes on .changes file, test ok
-    return true if pr_contains_changelog? || no_changelog_needed? || magic_comment?
+    return true if pr_contains_changelog? || magic_checkbox? || magic_comment?
 
     false
   end
@@ -43,13 +43,12 @@ class ChangelogTests
     end
   end
 
-  def no_changelog_needed?
+  def magic_checkbox?
     return false if pr_num.nil?
 
     pr = @client.pull_request(repo, pr_num)
     return true unless pr.body.include? '[x] No changelog needed'
 
-    puts 'Skipping changelog update verification'
     false
   end
 


### PR DESCRIPTION
## What does this PR do?

Fix the bug discussed here #166, where gitarro was adding a pending status on PR, when it runs with --check parameter.

In addition, when the test doesn't apply, we'll unmark the checkbox but we will include a comment to tell the user that this test was skipped.

A bit out of the scope, I also fixed something on gitarro.rb, so if we call the command with a -P parameter, we don't need to checkout all the PRs from github and jump in an iterator, as we can just checkout directly the PR passed by param.

I changed version, to save a commit, let me know if you prefer in a different commit.

## What issues does this PR fix or reference?

 - https://github.com/openSUSE/gitarro/issues/166

## Tests written? 

I improved those related with rerun, so now it lets a cleaner environment
