### PR TITLE
Uncheck re-run checbox even whith --check parameter, -P parameter now check the status and file filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog Gitarro
 
+## 0.1.85
+
+- uncheck the re-run checkbox even if --check option is passed by parameter
+- triggered_by_pr_number will trigger a concrete PR by doing the same checks than unreviewed_new_pr
+
 ## 0.1.84
 
 - Fix the bug discussed in #166

--- a/gem/gitarro.gemspec
+++ b/gem/gitarro.gemspec
@@ -1,6 +1,6 @@
 require 'date'
 
-GITARRO_VERSION = '0.1.84'.freeze
+GITARRO_VERSION = '0.1.85'.freeze
 GITARRO_TODAY = Date.today.strftime('%Y-%m-%d')
 Gem::Specification.new do |s|
   s.name = 'gitarro'

--- a/gitarro.rb
+++ b/gitarro.rb
@@ -16,7 +16,7 @@ exit 0 if prs.empty?
 prs.each do |pr|
   puts '=' * 30 + "\n" + "TITLE_PR: #{pr.title}, NR: #{pr.number}\n" + '=' * 30
   # check if prs contains the branch given otherwise just break
-  next unless b.pr_equal_spefic_branch?(pr)
+  next unless b.pr_equal_specific_branch?(pr)
 
   # this check the last commit state, catch for review or not reviewd status.
   comm_st = b.client.status(b.repo, pr.head.sha)


### PR DESCRIPTION
## What does this PR do?

In order to follow the same behavior that the magic comments are doing, we should uncheck the re-run checkbox even if we have --check parameter on gitarro command.