### PR TITLE
Refactoring the PR parameter

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -114,8 +114,19 @@ Style/StringLiterals:
   Exclude:
     - 'lib/gitarro/backend.rb'
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
 # Offense count: 3
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Metrics/LineLength:
   Max: 91
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+  - 'lib/gitarro/opt_parser.rb'
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog Gitarro
 
+## 0.1.86
+
+- Triggered_by_pr_number method removed
+- We will use --PR parameter only to don't iterate through all open PRs
+- Force_test parameter added. it force to run a test, even if is not marked to be re-triggered
+
 ## 0.1.85
 
 - uncheck the re-run checkbox even if --check option is passed by parameter

--- a/doc/BASICS.md
+++ b/doc/BASICS.md
@@ -30,6 +30,7 @@ Optional options:
     -f, --file '.py'                 pr_file type to filter/trigger the test against: .py, .rb
     -d, --description 'DESCRIPTION'  Test decription
     -C, --check                      Check if there is any PR requiring a test, but do not run it.
+    -F, --force_test                 Force to run a test, even if is not marked to be re-triggered.
     -u, --url 'TARGET_URL'           Specify the URL to append to add to the GitHub review. Usually you                                   will use an URL to the Jenkins build log.
     -P  --PR 'NUMBER'                Specify the PR number instead of checking all of them. This will                                     force gitarro to run the against a specific PR number,even if it is                                  not needed (useful for using Jenkins with GitHub webhooks).
         --https                      If present, use https instead of ssh for git operations

--- a/gem/gitarro.gemspec
+++ b/gem/gitarro.gemspec
@@ -1,6 +1,6 @@
 require 'date'
 
-GITARRO_VERSION = '0.1.85'.freeze
+GITARRO_VERSION = '0.1.86'.freeze
 GITARRO_TODAY = Date.today.strftime('%Y-%m-%d')
 Gem::Specification.new do |s|
   s.name = 'gitarro'

--- a/lib/gitarro/opt_parser.rb
+++ b/lib/gitarro/opt_parser.rb
@@ -37,6 +37,11 @@ module OptionalOptions
     opt.on('-C', '--check', desc) { |check| @options[:check] = check }
   end
 
+  def force_test_opt(opt)
+    desc = 'Force to run a test, even if is not marked to be re-triggered.'
+    opt.on('-F', '--force_test', desc) { |force_test| @options[:force_test] = force_test }
+  end
+
   def no_shallow(opt)
     desc = 'If enabled, gitarro will not use git shallow clone'
     opt.on('--noshallow', desc) { |noshallow| @options[:noshallow] = noshallow }
@@ -106,6 +111,7 @@ module OptionalOptions
     opt.separator "\n Optional options:"
     desc_opt(opt)
     check_opt(opt)
+    force_test_opt(opt)
     branch_opt(opt)
     no_shallow(opt)
     file_opt(opt)
@@ -171,6 +177,7 @@ class OptParserInternal
 
   # set some default values
   def defaults_false
+    @options[:force_test] = false if @options[:force_test].nil?
     @options[:check] = false if @options[:check].nil?
     @options[:target_url] = '' if @options[:target_url].nil?
     @options[:https] = false if @options[:https].nil?

--- a/tests/spec/secondary2_spec.rb
+++ b/tests/spec/secondary2_spec.rb
@@ -45,6 +45,15 @@ describe 'secondary2 features' do
     expect(output).not_to match(/^\[TESTREQUIRED=true\].*/)
   end
 
+  it 'gitarro should re-run the test if we force it for a specific PR' do
+    context = 'pr-force-test-only-one-pr'
+    rgit.change_description(pr, "- [x] Re-run test \"#{context}\"")
+    result, output = test.force_test_with_specific_pr(comm_st, pr.number, context)
+    rgit.change_description(pr, '')
+    expect(result).to be true
+    expect(output).not_to match(/^\[TESTREQUIRED=true\].*/)
+  end
+
   # env variables
   it 'Passing env variable to script, we can use them in script' do
     cont = 'env_test_script'

--- a/tests/spec/test_lib.rb
+++ b/tests/spec/test_lib.rb
@@ -118,13 +118,23 @@ class GitarroTestingCmdLine
     File.file?('/tmp/foo2')
   end
 
-  def changed_since(com_st, sec, cont)
+  def changed_since(comm_st, sec, cont)
     gitarro = "#{script} -r #{repo} -c #{cont} -d #{cont} -g #{git_dir}" \
               " -t #{valid_test} -f #{ftype} -u #{url}"
     changed_since_param = "--changed_since #{sec}" if sec >= 0
     puts stdout = `ruby #{gitarro} #{changed_since_param}`
-    [failed_status(com_st, cont) && (sec > 0 || sec < 0) ? false : true,
+    [failed_status(comm_st, cont) && (sec > 0 || sec < 0) ? false : true,
      stdout]
+  end
+
+  def force_test_with_specific_pr(comm_st, pr_number, cont)
+    gitarro = "#{script} --force_test --PR #{pr_number} -r #{repo} -c #{cont} -d #{cont} -g #{git_dir}" \
+              " -t #{valid_test} -f #{ftype} -u #{url}"
+
+    puts `ruby #{gitarro}`
+    raise 'GITARRO SHOULDNT FAIL' if failed_status(comm_st, cont)
+
+    true
   end
 
   def noshallow(comm_st, cont)


### PR DESCRIPTION
## What does this PR do?

* My last PR doesn't catch the case of re-run a tests, as we were running re-trigger by PR, exactly like unreviewed_pr method but without the iteration through all the PRs. For some reason, the unittests didn't catch it, I would need to improve them at some point...

What we need is to check exactly the same steps, but only for the specified PR, so:
- b.pr_equal_specific_branch?(pr)
- b.retrigger_check(pr)
- b.unreviewed_new_pr?(pr, comm_st)
- b.reviewed_pr?(comm_st, pr)

* Also, we change the main loop, so now we don't break the loop with first test passed on first PR pending, instead we iterate through all the known pending PRs and run the tests if possible.

* In the other hand, we found a corner case with contexts that you want to re-trigger but you don't want to have a comment or checkbox on the PR. For that case, we created the new parameter `--force_test` that will directly run the test for that PR number without check other filters.