### PR TITLE
(don't merge yet) append token when using https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog Gitarro
 
+## 0.1.86
+
+- fix: append token to http url correctly
+- minor: remove rendundant attribute.
+
 ## 0.1.85
 
 - uncheck the re-run checkbox even if --check option is passed by parameter


### PR DESCRIPTION
## What does this PR do?
- when using token from Github one needs to append it in the url ( before we were assuming ssh-key)
- remove protocol_attribute 
