### PR TITLE
Fix the regular expression for re-run tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog Gitarro
 
+## 0.1.87
+
+- Fix regular expression to Re-run tests
+
 ## 0.1.86
 
 - Triggered_by_pr_number method removed

--- a/gem/gitarro.gemspec
+++ b/gem/gitarro.gemspec
@@ -1,6 +1,6 @@
 require 'date'
 
-GITARRO_VERSION = '0.1.86'.freeze
+GITARRO_VERSION = '0.1.87'.freeze
 GITARRO_TODAY = Date.today.strftime('%Y-%m-%d')
 Gem::Specification.new do |s|
   s.name = 'gitarro'

--- a/lib/gitarro/backend.rb
+++ b/lib/gitarro/backend.rb
@@ -275,7 +275,7 @@ class Backend
   # this function will check if the PR contains a checkbox
   # for retrigger all the tests.
   def retriggered_by_checkbox?(pr, context)
-    return false unless pr.body.match(/\[x\]\s+Re-run\s+test\s+#{context}/i)
+    return false unless pr.body.match(/\[x\]\s+Re-run\s+test\s+"#{context}"/i)
 
     skipped = ''
     unless empty_files_changed_by_pr?(pr)

--- a/tests/spec/test_lib.rb
+++ b/tests/spec/test_lib.rb
@@ -128,8 +128,8 @@ class GitarroTestingCmdLine
   end
 
   def force_test_with_specific_pr(comm_st, pr_number, cont)
-    gitarro = "#{script} --force_test --PR #{pr_number} -r #{repo} -c #{cont} -d #{cont} -g #{git_dir}" \
-              " -t #{valid_test} -f #{ftype} -u #{url}"
+    gitarro = "#{script} --force_test --PR #{pr_number} -r #{repo} -c #{cont}" \
+              " -d #{cont} -g #{git_dir} -t #{valid_test} -f #{ftype} -u #{url}"
 
     puts `ruby #{gitarro}`
     raise 'GITARRO SHOULDNT FAIL' if failed_status(comm_st, cont)


### PR DESCRIPTION
## What does this PR do?

This PR fix an error introduced in `retriggered_by_checkbox?` when we changed include by a regular expression.

