### PR TITLE
Set upper limit for rubocop version

### DIFF
--- a/gem/gitarro.gemspec
+++ b/gem/gitarro.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest-reporters', '~> 1.1'
   s.add_development_dependency 'rake', '>= 12.3.3'
   s.add_development_dependency 'rspec', '~> 3.6'
-  s.add_development_dependency 'rubocop', '~> 0.49'
+  s.add_development_dependency 'rubocop', '>= 0.49', '<= 0.83.0'
   s.add_development_dependency 'rubocop-rspec', '~> 1.19'
   s.metadata = {
 	   'changelog_uri' => 'https://github.com/openSUSE/gitarro/blob/master/CHANGELOG.md'


### PR DESCRIPTION
## What does this PR do?
Prevent recurrent breakages in our ruby style tests.

From time to time our ruby tests use a newer rubocop version
shipping with new cops causing troubles.
Fix the maximum rubocop version to prevent breakages.

## What issues does this PR fix or reference?
- None
 
