### PR TITLE
Make the gem compatible with Ruby 2.5 again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,13 @@
 source 'https://rubygems.org'
 
 gem 'english'
+gem 'farday', '<= 1.10.2'
+gem 'faraday-net_http', '<= 2.1.0'
 gem 'minitest'
 gem 'minitest-reporters'
 gem 'netrc'
 gem 'octokit'
+gem 'public_suffix', '<= 4.0.7'
 gem 'rake'
 gem 'reek'
 gem 'rspec'

--- a/gem/gitarro.gemspec
+++ b/gem/gitarro.gemspec
@@ -17,9 +17,12 @@ Gem::Specification.new do |s|
   s.files = ['lib/gitarro/backend.rb',
              'lib/gitarro/opt_parser.rb', 'lib/gitarro/git_op.rb']
   s.executables = 'gitarro'
+  s.add_dependency 'faraday', '<= 1.10.2'
+  s.add_dependency 'faraday-net_http', '<= 2.1.0'
   s.add_dependency 'english', '~> 0.6'
   s.add_dependency 'netrc', '~> 0.11'
   s.add_dependency 'octokit', '~> 4.7'
+  s.add_dependency 'public_suffix', '<= 4.0.7'
   s.add_development_dependency 'minitest', '~> 5.9'
   s.add_development_dependency 'minitest-reporters', '~> 1.1'
   s.add_development_dependency 'rake', '>= 12.3.3'


### PR DESCRIPTION
## What does this PR do?

Make the gem compatible with Ruby 2.5 again

## What issues does this PR fix or reference?

None

## Tests written? 

No

## Workflow:

https://github.com/openSUSE/gitarro/blob/master/doc/CONTRIBUTING.md
